### PR TITLE
editor crash fix

### DIFF
--- a/scripts/ghost-gui.lua
+++ b/scripts/ghost-gui.lua
@@ -197,7 +197,7 @@ local update_gui_content = function(player)
 
                 -- Do some calculations
                 local delta = util.arr_cnt(gt.ghosts) - gt.storage.total_count
-                local craftable = player.get_craftable_count(itm) or 0
+                local craftable = (player.controller_type ~= defines.controllers.editor) and (player.get_craftable_count(itm) or 0) or 0
                 local threshold = math.min(delta, craftable)
 
                 -- Set background tint


### PR DESCRIPTION
Fixes non-recoverable error caused by calling 'get_crafting_count'.
This would occur when player enters the editor mode with the mod ui open, or opening the ui while in editor mode.